### PR TITLE
feat: add GitLab CI/CD pipeline and deployment instructions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ image: node:24
 # Override in Settings → CI/CD → Variables:
 #   ASTRO_SITE  Full URL of your deployed site, e.g. https://username.gitlab.io
 #   ASTRO_BASE  Base path for project pages, e.g. /repo-name
-#               Leave empty ("") for user/group pages (username.gitlab.io)
+#               Leave unset for user/group pages (username.gitlab.io)
 # ──────────────────────────────────────────────────────────────────────────────
 variables:
   NODE_ENV: production
@@ -54,13 +54,13 @@ build:
     paths:
       - dist/
     expire_in: 1 week
-  rules:
-    - if: '$CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH'
 
 pages:
   stage: deploy
+  needs: [build]
+  before_script: []
   script:
-    - yarn build
+    - echo "Publishing dist/ to GitLab Pages"
   pages:
     publish: dist
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,70 @@
+image: node:24
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Override in Settings → CI/CD → Variables:
+#   ASTRO_SITE  Full URL of your deployed site, e.g. https://username.gitlab.io
+#   ASTRO_BASE  Base path for project pages, e.g. /repo-name
+#               Leave empty ("") for user/group pages (username.gitlab.io)
+# ──────────────────────────────────────────────────────────────────────────────
+variables:
+  NODE_ENV: production
+  ASTRO_SITE: https://username.gitlab.io
+  ASTRO_BASE: /as-folio
+
+stages:
+  - validate
+  - test
+  - build
+  - deploy
+
+cache:
+  key: "$CI_COMMIT_REF_SLUG"
+  paths:
+    - .yarn/cache/
+    - node_modules/
+
+before_script:
+  - corepack enable
+  - yarn install --immutable
+
+typecheck:
+  stage: validate
+  interruptible: true
+  script:
+    - yarn test:types
+
+lint:
+  stage: validate
+  interruptible: true
+  script:
+    - yarn lint:ci
+
+unit-test:
+  stage: test
+  interruptible: true
+  script:
+    - yarn test
+
+build:
+  stage: build
+  interruptible: true
+  script:
+    - yarn build
+  artifacts:
+    paths:
+      - dist/
+    expire_in: 1 week
+  rules:
+    - if: '$CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH'
+
+pages:
+  stage: deploy
+  script:
+    - yarn build
+  pages:
+    publish: dist
+  artifacts:
+    paths:
+      - dist
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'

--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ Already configured. Push to `main` after:
 2. Setting `base: ''` (user page) or `base: '/repo-name'` (project page) in `site.ts`
 3. Setting `url: 'https://your-username.github.io'` in `site.ts`
 
+### GitLab Pages
+
+Already configured in `.gitlab-ci.yml`. Push to your default branch after:
+
+1. Forking or mirroring this repo to GitLab
+2. Going to **Settings** → **CI/CD** → **Variables** and adding:
+   - `ASTRO_SITE` — full URL, e.g. `https://username.gitlab.io` or your custom domain
+   - `ASTRO_BASE` — base path for project pages, e.g. `/as-folio`; set to `""` (empty string) for user/group pages (`username.gitlab.io`)
+3. Pushing to your default branch — the pipeline runs typecheck → lint → unit tests → deploy automatically
+
 ### Cloudflare Pages
 
 ```

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Already configured in `.gitlab-ci.yml`. Push to your default branch after:
 1. Forking or mirroring this repo to GitLab
 2. Going to **Settings** → **CI/CD** → **Variables** and adding:
    - `ASTRO_SITE` — full URL, e.g. `https://username.gitlab.io` or your custom domain
-   - `ASTRO_BASE` — base path for project pages, e.g. `/as-folio`; set to `""` (empty string) for user/group pages (`username.gitlab.io`)
+   - `ASTRO_BASE` — base path for project pages, e.g. `/as-folio`; leave unset for user/group pages (`username.gitlab.io`)
 3. Pushing to your default branch — the pipeline runs typecheck → lint → unit tests → deploy automatically
 
 ### Cloudflare Pages


### PR DESCRIPTION
This pull request introduces GitLab CI/CD support for the project, enabling automated validation, testing, building, and deployment to GitLab Pages. The main changes include adding a complete `.gitlab-ci.yml` configuration and updating the documentation to guide users through the GitLab Pages setup process.

**CI/CD Pipeline Integration:**

* Added `.gitlab-ci.yml` with stages for validation (`typecheck`, `lint`), testing (`unit-test`), building (`build`), and deployment (`pages`) to automate the workflow using Node.js 24 and Yarn. The configuration also supports caching dependencies and setting environment variables for deployment.

**Documentation Updates:**

* Updated `README.md` with a new section detailing how to configure and use GitLab Pages, including instructions for setting required CI/CD variables and an overview of the pipeline steps.