### PR TITLE
chore(deps): bump checkout & setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Type-check, lint, test, build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - uses: actions/setup-node@v5
         with:
           node-version: '24'
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - uses: actions/setup-node@v5
         with:
           node-version: '24'
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/update-citations.yml
+++ b/.github/workflows/update-citations.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/.github/workflows/update-citations.yml
+++ b/.github/workflows/update-citations.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
       - uses: actions/setup-node@v5
         with:
           node-version: '24'
-
-      - name: Enable Corepack (Yarn 4)
-        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
Bumps `actions/checkout` and `actions/setup-node` from v4 to v5 so the workflows run
on the Node 24 runtime instead of the [deprecated Node.js 20][1]. ~~Version-only change,
no behavior difference.~~

**Edit:** also reorders one step — `Enable Corepack` now runs **before** `actions/setup-node` in all three workflows. This is required, not cosmetic: `setup-node@v5` auto-probes the package manager (`yarn cache dir`) *during its own step*, even with no `cache:` input; with Corepack enabled *after*, that probe runs under the runner's bundled Yarn Classic 1.22.22 and errors on the `packageManager: yarn@4.13.0` pin — the original CI failure. Enabling Corepack first makes the probe resolve Yarn 4. Node toolchain selection is unaffected (install/build run under Yarn 4.13.0 — verified green on Node 24).

[1]: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Assisted by [Claude Code](https://claude.com/claude-code)