### PR TITLE
fix(og): slice the font buffer before satori (intermittent "Unsupported OpenType signature")

### DIFF
--- a/src/pages/og/[...path].png.ts
+++ b/src/pages/og/[...path].png.ts
@@ -25,13 +25,13 @@ const fontBold = readFileSync(resolve(fontRoot, 'roboto-latin-700-normal.woff'))
 const FONTS = [
   {
     name: 'Roboto',
-    data: fontRegular.buffer as ArrayBuffer,
+    data: fontRegular,
     weight: 400 as const,
     style: 'normal' as const,
   },
   {
     name: 'Roboto',
-    data: fontBold.buffer as ArrayBuffer,
+    data: fontBold,
     weight: 700 as const,
     style: 'normal' as const,
   },


### PR DESCRIPTION
src/pages/og/[...path].png.ts` passes `fontRegular.buffer` / `fontBold.buffer` to satori. A Node `Buffer` shares a **pooled** `ArrayBuffer`, so `.buffer` is the *whole pool*, not the font's slice. When a read lands at a non-zero pool offset (e.g. the 2nd of the two font reads), satori parses the leading pool bytes as the font header → `Unsupported OpenType signature <garbage>`, failing `astro build`.

It's non-deterministic (pool layout), so it passes on most runs but fails reliably once the build runs on **Node 24** — which `.nvmrc`, `engines`, and the workflows all target.

**Fix:** ~~slice each buffer to `[byteOffset, byteOffset+byteLength]`. Keeps the existing Roboto WOFF (satori unwraps WOFF fine) — no font swap, no new dependency.~~ **Edit:** even simpler — satori's README says to pass the font as a Buffer (Node) / ArrayBuffer (web), and a Node `Buffer` already carries the correct `byteOffset`/length, so just drop the `.buffer` extraction (`data: fontRegular`). Keeps the existing Roboto WOFF (satori unwraps WOFF fine) — no font swap, no new dependency.

**Proof on Node 24** (this repo's `main` CI doesn't effectively build on 24, so the failure can't show here): stacked on #6's Node-24 branch, this exact commit flips the build green — all 34 `/og/*` cards render, incl. `advanced-post-features.png` which crashes without it. **This also unblocks #6.**

- ci test pr in my repo: https://github.com/SeungJong-Ha/as-folio/pull/2

---
🤖 Assisted by [Claude Code](https://claude.com/claude-code)