### PR TITLE
fix(theme): honor site theme.color, add hover config

### DIFF
--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -436,10 +436,13 @@ export const site = {
      *   Red:              { light: '#ff3636', dark: '#f29105' }
      *   Green:            { light: '#009f06', dark: '#b7d12a' }
      *   Orange:           { light: '#f29105', dark: '#efcc00' }
+     *   Custom hover:     { light: '#0076df', dark: '#68c0d9', hoverLight: '#0a53be', hoverDark: '#9fd8ea' }
      */
     color: {
       light: 'auto' as string,
       dark: 'auto' as string,
+      hoverLight: 'auto' as string,
+      hoverDark: 'auto' as string,
     },
   },
 } as const;

--- a/src/content/posts/dark-mode-and-theming.mdx
+++ b/src/content/posts/dark-mode-and-theming.mdx
@@ -80,13 +80,17 @@ new MutationObserver(() => {
 
 ## Customising the accent colour
 
-The theme colour is set in `src/config/site.ts` as a comment/reference, but the actual CSS variables are in `src/styles/_colors.css`. To change the accent, update `--global-theme-color` (and optionally `--global-hover-color`) in both `:root` and `[data-theme="dark"]`:
+The theme colour is set in `src/config/site.ts` under `theme.color`. To change the accent, update `light` and `dark` (and optionally `hoverLight` and `hoverDark`) — each takes any CSS colour, or `'auto'` for the built-in default:
 
-```css
-:root {
-  --global-theme-color: #0070f3; /* Vercel blue */
-  --global-hover-color: #005cc5;
-}
+```ts
+theme: {
+  color: {
+    light: '#0070f3', /* Vercel blue */
+    dark: '#68c0d9',
+    hoverLight: 'auto',
+    hoverDark: 'auto',
+  },
+},
 ```
 
 That's all — every badge, link highlight, tag pill, and interactive element picks it up automatically.

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -36,19 +36,21 @@ const resolvedImage = image?.startsWith('/')
   : image;
 const ogImage = resolvedImage ? new URL(resolvedImage, site.url).toString() : undefined;
 
-// Theme color override — only injected when site.theme.color is not 'auto'
-const lightColor = site.theme.color.light === 'auto' ? null : site.theme.color.light;
-const darkColor = site.theme.color.dark === 'auto' ? null : site.theme.color.dark;
-const colorOverrideStyle = [
-  lightColor
-    ? `:root,[data-theme='light']{--global-theme-color:${lightColor};--global-hover-color:${lightColor};}`
-    : '',
-  darkColor
-    ? `[data-theme='dark']{--global-theme-color:${darkColor};--global-hover-color:${darkColor};}`
-    : '',
+// Theme color override — emit --user-* vars consumed by _colors.css ('auto' → palette default)
+const color = site.theme.color;
+const accentLight = color.light === 'auto' ? null : color.light;
+const accentDark = color.dark === 'auto' ? null : color.dark;
+const hoverLight = color.hoverLight === 'auto' ? null : color.hoverLight;
+const hoverDark = color.hoverDark === 'auto' ? null : color.hoverDark;
+const decls = [
+  accentLight && `--user-accent-light:${accentLight};`,
+  hoverLight && `--user-hover-light:${hoverLight};`,
+  accentDark && `--user-accent-dark:${accentDark};`,
+  hoverDark && `--user-hover-dark:${hoverDark};`,
 ]
   .filter(Boolean)
   .join('');
+const colorOverrideStyle = decls ? `:root{${decls}}` : '';
 
 // Person JSON-LD for homepage — helps search engines associate content with the author
 const personJsonLd = isHome ? JSON.stringify({

--- a/src/styles/_colors.css
+++ b/src/styles/_colors.css
@@ -46,8 +46,8 @@
   --global-code-bg-color: #f3f4f6;
   --global-text-color: #1a1a1a;
   --global-text-color-light: #6c757d;
-  --global-theme-color: var(--color-purple);
-  --global-hover-color: var(--color-purple-dark);
+  --global-theme-color: var(--user-accent-light, var(--color-purple));
+  --global-hover-color: var(--user-hover-light, var(--color-purple-dark));
   --global-hover-text-color: var(--color-white);
   --global-dropdown-hover-bg: var(--color-purple-dark);
   --global-dropdown-hover-text: var(--color-white);
@@ -87,8 +87,8 @@ html[data-theme='dark'] {
   --global-code-bg-color: var(--color-code-bg-dark);
   --global-text-color: var(--color-grey-light);
   --global-text-color-light: #9e9e9e;
-  --global-theme-color: var(--color-cyan);
-  --global-hover-color: var(--color-cyan);
+  --global-theme-color: var(--user-accent-dark, var(--color-cyan));
+  --global-hover-color: var(--user-hover-dark, var(--color-cyan));
   --global-hover-text-color: var(--color-white);
   --global-dropdown-hover-bg: rgba(38, 152, 186, 0.12);
   --global-dropdown-hover-text: var(--global-text-color);


### PR DESCRIPTION
## Problem
Setting `theme.color` to a non-`auto` value had no effect: the override
`<style>` is emitted before the bundled global stylesheet, so at equal
specificity (`:root`) the stylesheet's default `--global-theme-color` wins the
cascade and the configured color is ignored.

## Fix
Publish the configured colors as `--user-*` custom properties that `_colors.css`
reads with the palette value as fallback:

```css
:root                   { --global-theme-color: var(--user-accent-light, var(--color-purple)); }
html[data-theme='dark'] { --global-theme-color: var(--user-accent-dark,  var(--color-cyan));   }
```

🤖 AI-assisted (Claude Opus 4.8), reviewed and tested by the author.