### PR TITLE
refactor(icons): replace astro-icon with unplugin-icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,10 @@ yarn format         # Prettier
 
 ### Icons
 
-- `astro-icon` with `@iconify-json/fa-brands`, `@iconify-json/fa-solid`, `@iconify-json/fa-regular`
+- `unplugin-icons` (`compiler: 'astro'`) with `@iconify-json/fa-brands`, `@iconify-json/fa-solid`, `@iconify-json/fa-regular`
 - `@iconify-json/academicons` for academic social icons
-- Usage: `<Icon name="fa-brands:github" />` or `<Icon name="academicons:google-scholar" />`
+- Usage: `import IconGithub from '~icons/fa-brands/github'` → `<IconGithub />` (unknown name = build error)
+- Data-driven icons: put the component in the data — `{ Icon: IconGithub }` → `<item.Icon />`
 
 ### BibTeX
 
@@ -122,18 +123,18 @@ yarn format         # Prettier
 
 ## Common pitfalls
 
-| Issue                        | Fix                                                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `render()` error             | Use `const { Content } = await render(entry)` (Astro 6 API)                                                      |
-| YAML number parsed as string | Use `z.coerce.string()` in schema                                                                                |
-| Dark mode flash              | Ensure `<script is:inline>` with `localStorage` check is in `<head>` before CSS                                  |
-| Nested `<a>` elements        | Use `data-href` + JS click handler for clickable cards; inner links stay real `<a>`                              |
-| `as const` type error        | Use `as 'literal'` type assertion for string union fields in site config                                         |
-| ISBN coercion                | Always `z.coerce.string()` for isbn/olid fields                                                                  |
-| Icon not found at build      | Add new icon names to the `icon.include['fa-solid']` array in `astro.config.mjs`                                 |
-| Hardcoded persona string     | Never embed persona names (e.g. `'einstein'`) in components — pass all user-visible text as props from `site.ts` |
+| Issue                        | Fix                                                                                                                                                                                              |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `render()` error             | Use `const { Content } = await render(entry)` (Astro 6 API)                                                                                                                                      |
+| YAML number parsed as string | Use `z.coerce.string()` in schema                                                                                                                                                                |
+| Dark mode flash              | Ensure `<script is:inline>` with `localStorage` check is in `<head>` before CSS                                                                                                                  |
+| Nested `<a>` elements        | Use `data-href` + JS click handler for clickable cards; inner links stay real `<a>`                                                                                                              |
+| `as const` type error        | Use `as 'literal'` type assertion for string union fields in site config                                                                                                                         |
+| ISBN coercion                | Always `z.coerce.string()` for isbn/olid fields                                                                                                                                                  |
+| Icon not found at build      | Import it as `~icons/<collection>/<name>`; an unknown name is a build error, not a silent warning                                                                                                |
+| Hardcoded persona string     | Never embed persona names (e.g. `'einstein'`) in components — pass all user-visible text as props from `site.ts`                                                                                 |
 | Image zoom stuck / no close  | medium-zoom only attaches to `img[data-zoomable]`; use `<Figure zoomable />` to opt in. The `transitionend` failsafe (400ms timeout) handles environments where the CSS transition doesn't fire. |
-| BibTeX field shows in cite   | Add the field name to `BIBTEX_INTERNAL_FIELDS` in `src/utils/bibtex.ts` so it's stripped from the copyable citation block. |
+| BibTeX field shows in cite   | Add the field name to `BIBTEX_INTERNAL_FIELDS` in `src/utils/bibtex.ts` so it's stripped from the copyable citation block.                                                                       |
 
 ---
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,11 @@ import mdx from '@astrojs/mdx';
 import partytown from '@astrojs/partytown';
 import react from '@astrojs/react';
 import tailwindcss from '@tailwindcss/vite';
-import icon from 'astro-icon';
 import { defineConfig } from 'astro/config';
 import rehypeExternalLinks from 'rehype-external-links';
 import rehypeKatex from 'rehype-katex';
 import remarkMath from 'remark-math';
+import Icons from 'unplugin-icons/vite';
 
 /**
  * Remark plugin: rewrite root-relative src/href inside raw HTML blocks in .md files.
@@ -92,108 +92,13 @@ export default defineConfig({
         forward: ['dataLayer.push'],
       },
     }),
-    icon({
-      include: {
-        'fa-brands': [
-          'twitter',
-          'linkedin',
-          'github',
-          'gitlab',
-          'youtube',
-          'medium',
-          'mastodon',
-          'discord',
-          'whatsapp',
-          'telegram',
-          'weibo',
-          'instagram',
-          'facebook',
-          'pinterest',
-        ],
-        'fa-solid': [
-          'envelope',
-          'file-pdf',
-          'rss',
-          'moon',
-          'sun',
-          'bars',
-          'times',
-          'certificate',
-          'code',
-          'quote-left',
-          'chevron-up',
-          'search',
-          'link',
-          'star',
-          'book',
-          'graduation-cap',
-          'user',
-          'users',
-          'building',
-          'calendar',
-          'tag',
-          'tags',
-          'newspaper',
-          'chalkboard-teacher',
-          'flask',
-          'award',
-          'language',
-          'briefcase',
-          'globe',
-          'info-circle',
-          'video',
-          'music',
-          'map-pin',
-          'hashtag',
-          'magnifying-glass',
-          'thumbtack',
-          'external-link-alt',
-          'circle-arrow-right',
-          'book-open',
-          'check',
-          'clock',
-          'pause',
-          'eye',
-          'redo',
-          'share-alt',
-        ],
-        'fa-regular': ['comment', 'star', 'bookmark', 'heart'],
-        academicons: [
-          'google-scholar',
-          'orcid',
-          'researchgate',
-          'inspire',
-          'arxiv',
-          'hal',
-          'semantic-scholar',
-          'ieee',
-          'acm',
-          'springer',
-          'elsevier',
-          'pubmed',
-          'clarivate',
-          'zotero',
-          'mendeley',
-          'academia',
-          'cv',
-          'figshare',
-          'zenodo',
-          'dataverse',
-          'open-access',
-          'open-data',
-          'open-materials',
-          'osf',
-          'overleaf',
-          'impactstory',
-          'scirate',
-          'isidore',
-          'hypothesis',
-        ],
-      },
-    }),
   ],
   vite: {
-    plugins: [tailwindcss()],
+    // Icons are provided by unplugin-icons: each icon is a static
+    // `~icons/<collection>/<name>` import compiled to a zero-JS inline SVG.
+    // An unknown icon name fails the build (unresolved import) instead of a
+    // silent warning, so there is no hand-maintained include list to drift.
+    plugins: [tailwindcss(), Icons({ compiler: 'astro' })],
     resolve: {
       alias: {
         '@components': '/src/components',

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@iconify-json/fa-solid": "^1.2.2",
     "@resvg/resvg-js": "^2.6.2",
     "astro": "^6.4.8",
-    "astro-icon": "^1.1.5",
     "js-yaml": "^4.2.0",
     "medium-zoom": "^1.1.0",
     "ninja-keys": "^1.2.2",
@@ -91,7 +90,8 @@
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "satori": "^0.26.0",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "unplugin-icons": "^23.0.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -154,7 +154,7 @@ if (s.rss_icon) {
         style="color: var(--global-text-color); text-decoration: none; transition: color 0.15s;"
         class="social-link"
       >
-        <link.Icon width={size} height={size} />
+        <link.Icon width={size} height={size} aria-hidden="true" />
       </a>
     ))
   }

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,7 +1,23 @@
 ---
 import { site } from '@config/site';
 import { withBase } from '@utils/base';
-import { Icon } from 'astro-icon/components';
+
+import IconArxiv from '~icons/academicons/arxiv';
+import IconGoogleScholar from '~icons/academicons/google-scholar';
+import IconInspire from '~icons/academicons/inspire';
+import IconOrcid from '~icons/academicons/orcid';
+import IconResearchgate from '~icons/academicons/researchgate';
+import IconGithub from '~icons/fa-brands/github';
+import IconGitlab from '~icons/fa-brands/gitlab';
+import IconInstagram from '~icons/fa-brands/instagram';
+import IconLinkedin from '~icons/fa-brands/linkedin';
+import IconMastodon from '~icons/fa-brands/mastodon';
+import IconMedium from '~icons/fa-brands/medium';
+import IconTwitter from '~icons/fa-brands/twitter';
+import IconYoutube from '~icons/fa-brands/youtube';
+import IconEnvelope from '~icons/fa-solid/envelope';
+import IconFilePdf from '~icons/fa-solid/file-pdf';
+import IconRss from '~icons/fa-solid/rss';
 
 interface Props {
   /** Additional CSS classes for the container */
@@ -16,113 +32,113 @@ const s = site.socials;
 type SocialLink = {
   href: string;
   label: string;
-  icon: string;
+  Icon: typeof IconGithub;
 };
 
 const links: SocialLink[] = [];
 
 if (s.email) {
-  links.push({ href: `mailto:${s.email}`, label: 'Email', icon: 'fa-solid:envelope' });
+  links.push({ href: `mailto:${s.email}`, label: 'Email', Icon: IconEnvelope });
 }
 if (s.x_username) {
   links.push({
     href: `https://x.com/${s.x_username}`,
     label: 'X (Twitter)',
-    icon: 'fa-brands:twitter',
+    Icon: IconTwitter,
   });
 }
 if (s.linkedin_username) {
   links.push({
     href: `https://www.linkedin.com/in/${s.linkedin_username}`,
     label: 'LinkedIn',
-    icon: 'fa-brands:linkedin',
+    Icon: IconLinkedin,
   });
 }
 if (s.github_username) {
   links.push({
     href: `https://github.com/${s.github_username}`,
     label: 'GitHub',
-    icon: 'fa-brands:github',
+    Icon: IconGithub,
   });
 }
 if (s.gitlab_username) {
   links.push({
     href: `https://gitlab.com/${s.gitlab_username}`,
     label: 'GitLab',
-    icon: 'fa-brands:gitlab',
+    Icon: IconGitlab,
   });
 }
 if (s.scholar_userid) {
   links.push({
     href: `https://scholar.google.com/citations?user=${s.scholar_userid}`,
     label: 'Google Scholar',
-    icon: 'academicons:google-scholar',
+    Icon: IconGoogleScholar,
   });
 }
 if (s.orcid_id) {
   links.push({
     href: `https://orcid.org/${s.orcid_id}`,
     label: 'ORCID',
-    icon: 'academicons:orcid',
+    Icon: IconOrcid,
   });
 }
 if (s.inspire_id) {
   links.push({
     href: `https://inspirehep.net/authors/${s.inspire_id}`,
     label: 'InspireHEP',
-    icon: 'academicons:inspire',
+    Icon: IconInspire,
   });
 }
 if (s.researchgate_username) {
   links.push({
     href: `https://www.researchgate.net/profile/${s.researchgate_username}`,
     label: 'ResearchGate',
-    icon: 'academicons:researchgate',
+    Icon: IconResearchgate,
   });
 }
 if (s.arxiv_id) {
   links.push({
     href: `https://arxiv.org/a/${s.arxiv_id}.html`,
     label: 'arXiv',
-    icon: 'academicons:arxiv',
+    Icon: IconArxiv,
   });
 }
 if (s.youtube_id) {
   links.push({
     href: `https://www.youtube.com/@${s.youtube_id}`,
     label: 'YouTube',
-    icon: 'fa-brands:youtube',
+    Icon: IconYoutube,
   });
 }
 if (s.instagram_username) {
   links.push({
     href: `https://www.instagram.com/${s.instagram_username}`,
     label: 'Instagram',
-    icon: 'fa-brands:instagram',
+    Icon: IconInstagram,
   });
 }
 if (s.mastodon_url) {
-  links.push({ href: s.mastodon_url, label: 'Mastodon', icon: 'fa-brands:mastodon' });
+  links.push({ href: s.mastodon_url, label: 'Mastodon', Icon: IconMastodon });
 }
 if (s.bluesky_handle) {
   links.push({
     href: `https://bsky.app/profile/${s.bluesky_handle}`,
     label: 'Bluesky',
-    icon: 'fa-brands:twitter',
+    Icon: IconTwitter,
   });
 }
 if (s.medium_username) {
   links.push({
     href: `https://medium.com/@${s.medium_username}`,
     label: 'Medium',
-    icon: 'fa-brands:medium',
+    Icon: IconMedium,
   });
 }
 if (s.cv_pdf) {
-  links.push({ href: withBase(s.cv_pdf), label: 'CV', icon: 'fa-solid:file-pdf' });
+  links.push({ href: withBase(s.cv_pdf), label: 'CV', Icon: IconFilePdf });
 }
 if (s.rss_icon) {
-  links.push({ href: `${site.base}/feed.xml`, label: 'RSS', icon: 'fa-solid:rss' });
+  links.push({ href: `${site.base}/feed.xml`, label: 'RSS', Icon: IconRss });
 }
 ---
 
@@ -138,7 +154,7 @@ if (s.rss_icon) {
         style="color: var(--global-text-color); text-decoration: none; transition: color 0.15s;"
         class="social-link"
       >
-        <Icon name={link.icon} width={size} height={size} />
+        <link.Icon width={size} height={size} />
       </a>
     ))
   }

--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -3,7 +3,10 @@ import { site } from '@config/site';
 import { withBase } from '@utils/base';
 import { readingTime } from '@utils/reading-time';
 import type { CollectionEntry } from 'astro:content';
-import { Icon } from 'astro-icon/components';
+
+import IconCalendar from '~icons/fa-solid/calendar';
+import IconHashtag from '~icons/fa-solid/hashtag';
+import IconTag from '~icons/fa-solid/tag';
 
 /** A local post from the 'posts' collection. */
 type LocalPost = CollectionEntry<'posts'>;
@@ -80,14 +83,14 @@ const year = d.getFullYear();
         </p>
         <p class="post-tags">
           <a href={`${site.base}/blog/`}>
-            <Icon name="fa-solid:calendar" />
+            <IconCalendar />
             &nbsp;{year}
           </a>
           {tags.map((tag) => (
             <>
               &nbsp;&middot;&nbsp;
               <a href={`${site.base}/blog/tag/${tag}/`}>
-                <Icon name="fa-solid:hashtag" />
+                <IconHashtag />
                 &nbsp;{tag}
               </a>
             </>
@@ -96,7 +99,7 @@ const year = d.getFullYear();
             <>
               &nbsp;&middot;&nbsp;
               <a href={`${site.base}/blog/category/${cat}/`}>
-                <Icon name="fa-solid:tag" />
+                <IconTag />
                 &nbsp;{cat}
               </a>
             </>
@@ -135,14 +138,14 @@ const year = d.getFullYear();
       </p>
       <p class="post-tags">
         <a href={`${site.base}/blog/`}>
-          <Icon name="fa-solid:calendar" />
+          <IconCalendar />
           &nbsp;{year}
         </a>
         {tags.map((tag) => (
           <>
             &nbsp;&middot;&nbsp;
             <a href={`${site.base}/blog/tag/${tag}/`}>
-              <Icon name="fa-solid:hashtag" />
+              <IconHashtag />
               &nbsp;{tag}
             </a>
           </>
@@ -151,7 +154,7 @@ const year = d.getFullYear();
           <>
             &nbsp;&middot;&nbsp;
             <a href={`${site.base}/blog/category/${cat}/`}>
-              <Icon name="fa-solid:tag" />
+              <IconTag />
               &nbsp;{cat}
             </a>
           </>

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -1,7 +1,8 @@
 ---
 import { site } from '@config/site';
 import type { CollectionEntry } from 'astro:content';
-import { Icon } from 'astro-icon/components';
+
+import IconCalendar from '~icons/fa-solid/calendar';
 
 interface Props {
   posts: CollectionEntry<'posts'>[];
@@ -29,7 +30,7 @@ if (posts.length === 0) return;
               {post.data.title}
             </a>
             <div class="related-meta">
-              <Icon name="fa-solid:calendar" />
+              <IconCalendar />
               <time datetime={post.data.date.toISOString()}>{date}</time>
               {post.data.tags.length > 0 && (
                 <>

--- a/src/components/blog/SocialShare.astro
+++ b/src/components/blog/SocialShare.astro
@@ -1,5 +1,9 @@
 ---
-import { Icon } from 'astro-icon/components';
+import IconFacebook from '~icons/fa-brands/facebook';
+import IconLinkedin from '~icons/fa-brands/linkedin';
+import IconTwitter from '~icons/fa-brands/twitter';
+import IconEnvelope from '~icons/fa-solid/envelope';
+import IconShareAlt from '~icons/fa-solid/share-alt';
 
 interface Props {
   title: string;
@@ -19,22 +23,22 @@ const shareLinks = [
   {
     name: 'X (Twitter)',
     href: `https://twitter.com/intent/tweet?text=${enc.title}&url=${enc.url}`,
-    icon: 'fa-brands:twitter',
+    Icon: IconTwitter,
   },
   {
     name: 'LinkedIn',
     href: `https://www.linkedin.com/shareArticle?mini=true&url=${enc.url}&title=${enc.title}`,
-    icon: 'fa-brands:linkedin',
+    Icon: IconLinkedin,
   },
   {
     name: 'Facebook',
     href: `https://www.facebook.com/sharer/sharer.php?u=${enc.url}`,
-    icon: 'fa-brands:facebook',
+    Icon: IconFacebook,
   },
   {
     name: 'Email',
     href: `mailto:?subject=${enc.title}&body=${enc.description}%0A%0A${enc.url}`,
-    icon: 'fa-solid:envelope',
+    Icon: IconEnvelope,
   },
 ];
 ---
@@ -43,7 +47,7 @@ const shareLinks = [
   <p class="share-label">Share</p>
   <div class="share-icons">
     {
-      shareLinks.map(({ name, href, icon }) => (
+      shareLinks.map(({ name, href, Icon }) => (
         <a
           href={href}
           target="_blank"
@@ -52,7 +56,7 @@ const shareLinks = [
           title={`Share on ${name}`}
           class="share-link"
         >
-          <Icon name={icon} aria-hidden="true" />
+          <Icon aria-hidden="true" />
         </a>
       ))
     }
@@ -63,7 +67,7 @@ const shareLinks = [
       class="share-link share-native"
       hidden
     >
-      <Icon name="fa-solid:share-alt" aria-hidden="true" />
+      <IconShareAlt aria-hidden="true" />
     </button>
   </div>
 </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,12 @@ import Page from '@layouts/Page.astro';
 import { fetchExternalPosts } from '@utils/external-posts';
 import { readingTime } from '@utils/reading-time';
 import { getCollection } from 'astro:content';
-import { Icon } from 'astro-icon/components';
+
+import IconCalendar from '~icons/fa-solid/calendar';
+import IconHashtag from '~icons/fa-solid/hashtag';
+import IconTag from '~icons/fa-solid/tag';
+import IconTags from '~icons/fa-solid/tags';
+import IconThumbtack from '~icons/fa-solid/thumbtack';
 
 const localPosts = (await getCollection('posts'))
   .filter((p) => !p.data.hidden && !p.data.draft)
@@ -93,7 +98,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
         displayTags.map((tag, i) => (
           <>
             <li>
-              <Icon name="fa-solid:hashtag" /> <a href={`${site.base}/blog/tag/${tag}/`}>{tag}</a>
+              <IconHashtag /> <a href={`${site.base}/blog/tag/${tag}/`}>{tag}</a>
             </li>
             {i < displayTags.length - 1 && <p>&bull;</p>}
           </>
@@ -104,7 +109,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
         displayCategories.map((cat, i) => (
           <>
             <li>
-              <Icon name="fa-solid:tag" /> <a href={`${site.base}/blog/category/${cat}/`}>{cat}</a>
+              <IconTag /> <a href={`${site.base}/blog/category/${cat}/`}>{cat}</a>
             </li>
             {i < displayCategories.length - 1 && <p>&bull;</p>}
           </>
@@ -112,7 +117,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
       }
       {(displayTags.length > 0 || displayCategories.length > 0) && <p>&bull;</p>}
       <li>
-        <Icon name="fa-solid:tags" />{' '}
+        <IconTags />{' '}
         <a href={`${site.base}/blog/tags/`}>all tags</a>
       </li>
     </ul>
@@ -136,7 +141,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
                         <div class="col-md-12">
                           <div class="card-body">
                             <div class="float-right">
-                              <Icon name="fa-solid:thumbtack" style="font-size:0.75rem;" />
+                              <IconThumbtack style="font-size:0.75rem;" />
                             </div>
                             <h3 class="card-title text-lowercase">{post.data.title}</h3>
                             {post.data.description && (
@@ -145,7 +150,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
                             <p class="post-meta">
                               {mins} min read &nbsp;&middot;&nbsp;
                               <span>
-                                <Icon name="fa-solid:calendar" style="font-size:0.75rem;" /> {year}
+                                <IconCalendar style="font-size:0.75rem;" /> {year}
                               </span>
                             </p>
                           </div>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -5,7 +5,12 @@ import { site } from '@config/site';
 import PageLayout from '@layouts/Page.astro';
 import { readingTime } from '@utils/reading-time';
 import { getCollection } from 'astro:content';
-import { Icon } from 'astro-icon/components';
+
+import IconCalendar from '~icons/fa-solid/calendar';
+import IconHashtag from '~icons/fa-solid/hashtag';
+import IconTag from '~icons/fa-solid/tag';
+import IconTags from '~icons/fa-solid/tags';
+import IconThumbtack from '~icons/fa-solid/thumbtack';
 
 export async function getStaticPaths() {
   const allPosts = (await getCollection('posts'))
@@ -65,7 +70,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
         displayTags.map((tag, i) => (
           <>
             <li>
-              <Icon name="fa-solid:hashtag" /> <a href={`${base}/blog/tag/${tag}/`}>{tag}</a>
+              <IconHashtag /> <a href={`${base}/blog/tag/${tag}/`}>{tag}</a>
             </li>
             {i < displayTags.length - 1 && <p>&bull;</p>}
           </>
@@ -76,7 +81,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
         displayCategories.map((cat, i) => (
           <>
             <li>
-              <Icon name="fa-solid:tag" /> <a href={`${base}/blog/category/${cat}/`}>{cat}</a>
+              <IconTag /> <a href={`${base}/blog/category/${cat}/`}>{cat}</a>
             </li>
             {i < displayCategories.length - 1 && <p>&bull;</p>}
           </>
@@ -84,7 +89,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
       }
       {(displayTags.length > 0 || displayCategories.length > 0) && <p>&bull;</p>}
       <li>
-        <Icon name="fa-solid:tags" />{' '}
+        <IconTags />{' '}
         <a href={`${base}/blog/tags/`}>all tags</a>
       </li>
     </ul>
@@ -108,7 +113,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
                         <div class="col-md-12">
                           <div class="card-body">
                             <div class="float-right">
-                              <Icon name="fa-solid:thumbtack" style="font-size:0.75rem;" />
+                              <IconThumbtack style="font-size:0.75rem;" />
                             </div>
                             <h3 class="card-title text-lowercase">{post.data.title}</h3>
                             {post.data.description && (
@@ -117,7 +122,7 @@ const postYears = [...postsByYear.keys()].sort((a, b) => b - a);
                             <p class="post-meta">
                               {mins} min read &nbsp;&middot;&nbsp;
                               <span>
-                                <Icon name="fa-solid:calendar" style="font-size:0.75rem;" /> {year}
+                                <IconCalendar style="font-size:0.75rem;" /> {year}
                               </span>
                             </p>
                           </div>

--- a/src/pages/books.astro
+++ b/src/pages/books.astro
@@ -2,7 +2,14 @@
 import { site } from '@config/site';
 import Page from '@layouts/Page.astro';
 import { getCollection } from 'astro:content';
-import { Icon } from 'astro-icon/components';
+
+import IconBookOpen from '~icons/fa-solid/book-open';
+import IconCheck from '~icons/fa-solid/check';
+import IconClock from '~icons/fa-solid/clock';
+import IconEye from '~icons/fa-solid/eye';
+import IconPause from '~icons/fa-solid/pause';
+import IconRedo from '~icons/fa-solid/redo';
+import IconTimes from '~icons/fa-solid/times';
 
 const allBooks = await getCollection('books');
 
@@ -29,14 +36,14 @@ function booksForYear(year: number) {
 }
 
 // Status badge config
-const statusConfig: Record<string, { label: string; color: string; icon: string }> = {
-  reading: { label: 'reading', color: 'var(--global-theme-color)', icon: 'fa-solid:book-open' },
-  finished: { label: 'finished', color: '#4caf50', icon: 'fa-solid:check' },
-  queued: { label: 'queued', color: '#9e9e9e', icon: 'fa-solid:clock' },
-  paused: { label: 'paused', color: '#ff9800', icon: 'fa-solid:pause' },
-  abandoned: { label: 'abandoned', color: '#f44336', icon: 'fa-solid:times' },
-  interested: { label: 'interested', color: '#2196f3', icon: 'fa-solid:eye' },
-  reread: { label: 'reread', color: '#9c27b0', icon: 'fa-solid:redo' },
+const statusConfig: Record<string, { label: string; color: string; Icon: typeof IconBookOpen }> = {
+  reading: { label: 'reading', color: 'var(--global-theme-color)', Icon: IconBookOpen },
+  finished: { label: 'finished', color: '#4caf50', Icon: IconCheck },
+  queued: { label: 'queued', color: '#9e9e9e', Icon: IconClock },
+  paused: { label: 'paused', color: '#ff9800', Icon: IconPause },
+  abandoned: { label: 'abandoned', color: '#f44336', Icon: IconTimes },
+  interested: { label: 'interested', color: '#2196f3', Icon: IconEye },
+  reread: { label: 'reread', color: '#9c27b0', Icon: IconRedo },
 };
 
 function coverUrl(book: (typeof allBooks)[number]): string {
@@ -100,8 +107,7 @@ function renderStars(stars: number | undefined): string {
 
                     {badge && (
                       <span class="status-badge" style={`background-color: ${badge.color}`}>
-                        <Icon
-                          name={badge.icon}
+                        <badge.Icon
                           style="font-size: 0.65em; margin-right: 0.2em;"
                           aria-hidden="true"
                         />
@@ -158,8 +164,7 @@ function renderStars(stars: number | undefined): string {
 
                       {badge && (
                         <span class="status-badge" style={`background-color: ${badge.color}`}>
-                          <Icon
-                            name={badge.icon}
+                          <badge.Icon
                             style="font-size: 0.65em; margin-right: 0.2em;"
                             aria-hidden="true"
                           />

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -6,8 +6,9 @@ import Page from '@layouts/Page.astro';
 import { withBase } from '@utils/base';
 import type { JSONResume, RenderCV, RenderCVEntry } from '@utils/cv';
 import { formatCVDate, formatDateRange } from '@utils/cv';
-import { Icon } from 'astro-icon/components';
 import yaml from 'js-yaml';
+
+import IconFilePdf from '~icons/fa-solid/file-pdf';
 
 import cvRaw from '../data/cv.yml?raw';
 import resumeData from '../data/resume.json';
@@ -66,7 +67,7 @@ if (format === 'rendercv' && rc) {
             class="float-right"
             aria-label="Download CV PDF"
           >
-            <Icon name="fa-solid:file-pdf" />
+            <IconFilePdf />
           </a>
         )}
       </h1>

--- a/src/pages/teaching/index.astro
+++ b/src/pages/teaching/index.astro
@@ -2,7 +2,8 @@
 import { site } from '@config/site';
 import Page from '@layouts/Page.astro';
 import { getCollection, render } from 'astro:content';
-import { Icon } from 'astro-icon/components';
+
+import IconCalendar from '~icons/fa-solid/calendar';
 
 const all = await getCollection('teaching');
 
@@ -45,7 +46,7 @@ const timezone = site.teaching.timezone;
         calendarId && (
           <div class="post mt-4">
             <h2 class="mb-3">
-              <Icon name="fa-solid:calendar" style="font-size: 0.9em; margin-right: 0.4em;" />
+              <IconCalendar style="font-size: 0.9em; margin-right: 0.4em;" />
               Upcoming Events
             </h2>
             <button

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
+    "types": ["unplugin-icons/types/astro"],
     "paths": {
       "@components/*": ["./src/components/*"],
       "@layouts/*": ["./src/layouts/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,20 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@antfu/install-pkg@npm:^1.0.0":
+"@antfu/install-pkg@npm:^1.1.0":
   version: 1.1.0
   resolution: "@antfu/install-pkg@npm:1.1.0"
   dependencies:
     package-manager-detector: "npm:^1.3.0"
     tinyexec: "npm:^1.0.1"
   checksum: 10c0/140d5994c76fd3d0e824c88f1ce91b3370e8066a8bc2f5729ae133bf768caa239f7915e29c78f239b7ead253113ace51293e95127fafe2b786b88eb615b3be47
-  languageName: node
-  linkType: hard
-
-"@antfu/utils@npm:^8.1.0":
-  version: 8.1.1
-  resolution: "@antfu/utils@npm:8.1.1"
-  checksum: 10c0/cd55d322496f0324323a7bd312bbdc305db02f5c74c53d59213a00a7ecfd66926b6755a41f27c6e664a687cd7a967d3a8b12d3ea57f264ae45dd1c5c181f5160
   languageName: node
   linkType: hard
 
@@ -1335,23 +1328,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iconify/tools@npm:^4.0.5":
-  version: 4.2.0
-  resolution: "@iconify/tools@npm:4.2.0"
-  dependencies:
-    "@iconify/types": "npm:^2.0.0"
-    "@iconify/utils": "npm:^2.3.0"
-    cheerio: "npm:^1.1.2"
-    domhandler: "npm:^5.0.3"
-    extract-zip: "npm:^2.0.1"
-    local-pkg: "npm:^1.1.2"
-    pathe: "npm:^2.0.3"
-    svgo: "npm:^3.3.2"
-    tar: "npm:^7.5.2"
-  checksum: 10c0/2bc3f9a3976540bed5d1706ac0609e856ad4f498ddd7ffa0c30135cd9a4b92039e5fda4daa90f2eacef1470e16836f781105341083142daf32496a9b944789f7
-  languageName: node
-  linkType: hard
-
 "@iconify/types@npm:*, @iconify/types@npm:^2.0.0":
   version: 2.0.0
   resolution: "@iconify/types@npm:2.0.0"
@@ -1359,19 +1335,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iconify/utils@npm:^2.1.30, @iconify/utils@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "@iconify/utils@npm:2.3.0"
+"@iconify/utils@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "@iconify/utils@npm:3.1.4"
   dependencies:
-    "@antfu/install-pkg": "npm:^1.0.0"
-    "@antfu/utils": "npm:^8.1.0"
+    "@antfu/install-pkg": "npm:^1.1.0"
     "@iconify/types": "npm:^2.0.0"
-    debug: "npm:^4.4.0"
-    globals: "npm:^15.14.0"
-    kolorist: "npm:^1.8.0"
-    local-pkg: "npm:^1.0.0"
-    mlly: "npm:^1.7.4"
-  checksum: 10c0/926013852cd9d09b8501ee0f3f7d40386dc5ed1cb904869d6502f5ee1a64aee5664e9c00da49d700528d26c4a51ea0cac4f046c4eb281d0f8d54fc5df2f3fd0d
+    import-meta-resolve: "npm:^4.2.0"
+  checksum: 10c0/2176311415d5853e0e19056a833014324d0a98989936945fbcc4fb4b0ae92178f6ed13c9b4c8e1200191991b78af421b7dd49cc03b474c7a824696d73033e1c1
   languageName: node
   linkType: hard
 
@@ -2926,15 +2897,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yauzl@npm:^2.9.1":
-  version: 2.10.3
-  resolution: "@types/yauzl@npm:2.10.3"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/f1b7c1b99fef9f2fe7f1985ef7426d0cebe48cd031f1780fcdc7451eec7e31ac97028f16f50121a59bcf53086a1fc8c856fd5b7d3e00970e43d92ae27d6b43dc
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:8.61.1":
   version: 8.61.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.61.1"
@@ -3609,7 +3571,6 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.1.9"
     astro: "npm:^6.4.8"
     astro-eslint-parser: "npm:^1.4.0"
-    astro-icon: "npm:^1.1.5"
     eslint: "npm:^10.0.0"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
@@ -3639,6 +3600,7 @@ __metadata:
     tailwindcss: "npm:^4.3.1"
     typescript: "npm:^6.0.0"
     typescript-eslint: "npm:^8.61.1"
+    unplugin-icons: "npm:^23.0.1"
     vitest: "npm:^4.1.9"
   peerDependencies:
     astro: ">=6.0.0"
@@ -3696,17 +3658,6 @@ __metadata:
     is-glob: "npm:^4.0.3"
     semver: "npm:^7.3.8"
   checksum: 10c0/54afbef78e19d79e6cf3a86d268a6688282a5ff87d5c77e81202d14f567ef169aa18b822cba66245456ca126e3d90aee5f97ce706c86b27b2f7d508c6ca7444c
-  languageName: node
-  linkType: hard
-
-"astro-icon@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "astro-icon@npm:1.1.5"
-  dependencies:
-    "@iconify/tools": "npm:^4.0.5"
-    "@iconify/types": "npm:^2.0.0"
-    "@iconify/utils": "npm:^2.1.30"
-  checksum: 10c0/036a608928036868c727ec041cb1ef7e42000dbb272ad4357579678147cb1a3fd1be97a8e8d6f457ee58bcd9ac09f032da395b068f79a2ddd384f4aee44e91e4
   languageName: node
   linkType: hard
 
@@ -3923,13 +3874,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 10c0/cb0a8ddf5cf4f766466db63279e47761eb825693eeba6a5a95ee4ec8cb8f81ede70aa7f9d8aeec083e781d47154290eb5d4d26b3f7a465ec57fb9e7d59c47150
-  languageName: node
-  linkType: hard
-
 "buffer-image-size@npm:^0.6.4":
   version: 0.6.4
   resolution: "buffer-image-size@npm:0.6.4"
@@ -4052,39 +3996,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio-select@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "cheerio-select@npm:2.1.0"
-  dependencies:
-    boolbase: "npm:^1.0.0"
-    css-select: "npm:^5.1.0"
-    css-what: "npm:^6.1.0"
-    domelementtype: "npm:^2.3.0"
-    domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.0.1"
-  checksum: 10c0/2242097e593919dba4aacb97d7b8275def8b9ec70b00aa1f43335456870cfc9e284eae2080bdc832ed232dabb9eefcf56c722d152da4a154813fb8814a55d282
-  languageName: node
-  linkType: hard
-
-"cheerio@npm:^1.1.2":
-  version: 1.2.0
-  resolution: "cheerio@npm:1.2.0"
-  dependencies:
-    cheerio-select: "npm:^2.1.0"
-    dom-serializer: "npm:^2.0.0"
-    domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.2.2"
-    encoding-sniffer: "npm:^0.2.1"
-    htmlparser2: "npm:^10.1.0"
-    parse5: "npm:^7.3.0"
-    parse5-htmlparser2-tree-adapter: "npm:^7.1.0"
-    parse5-parser-stream: "npm:^7.1.2"
-    undici: "npm:^7.19.0"
-    whatwg-mimetype: "npm:^4.0.0"
-  checksum: 10c0/91a566aabfa9962f28056045bb7d92d79c0f8f3abb1fb86a852a9d1760556adddeb01a36b6f08fa7c133282375d387ae450a181a659e76c6a64016c30cc3f611
-  languageName: node
-  linkType: hard
-
 "chokidar@npm:^4.0.3":
   version: 4.0.3
   resolution: "chokidar@npm:4.0.3"
@@ -4202,13 +4113,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
-  languageName: node
-  linkType: hard
-
 "commander@npm:^8.3.0":
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
@@ -4247,7 +4151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"confbox@npm:^0.2.2":
+"confbox@npm:^0.2.4":
   version: 0.2.4
   resolution: "confbox@npm:0.2.4"
   checksum: 10c0/4c36af33d9df7034300c452f7b289179264493bd0671fa81b995a0d70dc897b1d37f1af10d3ffb187f178d17ba1ed2ba167ed0f599ba3a139c271205dd553f73
@@ -4407,16 +4311,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "css-tree@npm:2.3.1"
-  dependencies:
-    mdn-data: "npm:2.0.30"
-    source-map-js: "npm:^1.0.1"
-  checksum: 10c0/6f8c1a11d5e9b14bf02d10717fc0351b66ba12594166f65abfbd8eb8b5b490dd367f5c7721db241a3c792d935fc6751fbc09f7e1598d421477ad9fadc30f4f24
-  languageName: node
-  linkType: hard
-
 "css-tree@npm:^3.0.1, css-tree@npm:^3.1.0":
   version: 3.2.1
   resolution: "css-tree@npm:3.2.1"
@@ -4507,7 +4401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4658,7 +4552,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^3.0.1, domutils@npm:^3.2.2":
+"domutils@npm:^3.0.1":
   version: 3.2.2
   resolution: "domutils@npm:3.2.2"
   dependencies:
@@ -4745,25 +4639,6 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
-  languageName: node
-  linkType: hard
-
-"encoding-sniffer@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "encoding-sniffer@npm:0.2.1"
-  dependencies:
-    iconv-lite: "npm:^0.6.3"
-    whatwg-encoding: "npm:^3.1.1"
-  checksum: 10c0/d6b591880788f3baf8dd1744636dd189d24a1ec93e6f9817267c60ac3458a5191ca70ab1a186fb67731beff1c3489c6527dfdc4718158ed8460ab2f400dd5e7d
-  languageName: node
-  linkType: hard
-
-"end-of-stream@npm:^1.1.0":
-  version: 1.4.5
-  resolution: "end-of-stream@npm:1.4.5"
-  dependencies:
-    once: "npm:^1.4.0"
-  checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
   languageName: node
   linkType: hard
 
@@ -5484,10 +5359,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exsolve@npm:^1.0.7":
-  version: 1.0.8
-  resolution: "exsolve@npm:1.0.8"
-  checksum: 10c0/65e44ae05bd4a4a5d87cfdbbd6b8f24389282cf9f85fa5feb17ca87ad3f354877e6af4cd99e02fc29044174891f82d1d68c77f69234410eb8f163530e6278c67
+"exsolve@npm:^1.0.8":
+  version: 1.1.0
+  resolution: "exsolve@npm:1.1.0"
+  checksum: 10c0/38ecec58d6e4ddfe31b5e6773a0193057fcb8462e1c0959aee3c9441729b4db901f3b23af68963cb871fb3f83b46c49ed2f69e0ef6d5254951f483c68cc934e9
   languageName: node
   linkType: hard
 
@@ -5495,23 +5370,6 @@ __metadata:
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
-  languageName: node
-  linkType: hard
-
-"extract-zip@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 10c0/9afbd46854aa15a857ae0341a63a92743a7b89c8779102c3b4ffc207516b2019337353962309f85c66ee3d9092202a83cdc26dbf449a11981272038443974aee
   languageName: node
   linkType: hard
 
@@ -5620,15 +5478,6 @@ __metadata:
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/e5dd725884decb1f11e5c822221d76136f239d0236f176fab80b7b8f9e7619ae57e6b4e5b73defc21e6b9ef99437ee7b545cff8e6c2c337819633712fa9d352e
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10c0/304dd70270298e3ffe3bcc05e6f7ade2511acc278bc52d025f8918b48b6aa3b77f10361bddfadfe2a28163f7af7adbdce96f4d22c31b2f648ba2901f0c5fc20e
   languageName: node
   linkType: hard
 
@@ -5864,15 +5713,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "get-stream@npm:5.2.0"
-  dependencies:
-    pump: "npm:^3.0.0"
-  checksum: 10c0/43797ffd815fbb26685bf188c8cfebecb8af87b3925091dd7b9a9c915993293d78e3c9e1bce125928ff92f2d0796f3889b92b5ec6d58d1041b574682132e0a80
-  languageName: node
-  linkType: hard
-
 "get-symbol-description@npm:^1.1.0":
   version: 1.1.0
   resolution: "get-symbol-description@npm:1.1.0"
@@ -5947,13 +5787,6 @@ __metadata:
   dependencies:
     ini: "npm:6.0.0"
   checksum: 10c0/2b90eea8975bb332db7e8c9096ff310f0deb617d17e47e93b921d1c69f7677c1759a07009f2581f050d3ea08a3e079bf4ffdb9c34c94d48dc369c6577b3d45f4
-  languageName: node
-  linkType: hard
-
-"globals@npm:^15.14.0":
-  version: 15.15.0
-  resolution: "globals@npm:15.15.0"
-  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
   languageName: node
   linkType: hard
 
@@ -6328,18 +6161,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "htmlparser2@npm:10.1.0"
-  dependencies:
-    domelementtype: "npm:^2.3.0"
-    domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.2.2"
-    entities: "npm:^7.0.1"
-  checksum: 10c0/36394e29b80cfcc5e78e0fa4d3aa21fdaac3e6778d23e5c933e625c290987cd9a724a2eb0753ab60ed0c69dfaba0ab115f0ee50fb112fd8f0c4d522e7e0089a2
-  languageName: node
-  linkType: hard
-
 "http-cache-semantics@npm:^4.1.1, http-cache-semantics@npm:^4.2.0":
   version: 4.2.0
   resolution: "http-cache-semantics@npm:4.2.0"
@@ -6376,15 +6197,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "iconv-lite@npm:0.6.3"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.7.2":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
@@ -6415,6 +6227,13 @@ __metadata:
     parent-module: "npm:^1.0.0"
     resolve-from: "npm:^4.0.0"
   checksum: 10c0/bf8cc494872fef783249709385ae883b447e3eb09db0ebd15dcead7d9afe7224dad7bd7591c6b73b0b19b3c0f9640eb8ee884f01cfaf2887ab995b0b36a0cbec
+  languageName: node
+  linkType: hard
+
+"import-meta-resolve@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: 10c0/3ee8aeecb61d19b49d2703987f977e9d1c7d4ba47db615a570eaa02fe414f40dfa63f7b953e842cbe8470d26df6371332bfcf21b2fd92b0112f9fea80dde2c4c
   languageName: node
   linkType: hard
 
@@ -7058,13 +6877,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kolorist@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "kolorist@npm:1.8.0"
-  checksum: 10c0/73075db44a692bf6c34a649f3b4b3aea4993b84f6b754cbf7a8577e7c7db44c0bad87752bd23b0ce533f49de2244ce2ce03b7b1b667a85ae170a94782cc50f9b
-  languageName: node
-  linkType: hard
-
 "language-subtag-registry@npm:^0.3.20":
   version: 0.3.23
   resolution: "language-subtag-registry@npm:0.3.23"
@@ -7301,14 +7113,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"local-pkg@npm:^1.0.0, local-pkg@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "local-pkg@npm:1.1.2"
+"local-pkg@npm:^1.1.2":
+  version: 1.2.1
+  resolution: "local-pkg@npm:1.2.1"
   dependencies:
     mlly: "npm:^1.7.4"
     pkg-types: "npm:^2.3.0"
     quansync: "npm:^0.2.11"
-  checksum: 10c0/1bcfcc5528dea95cba3caa478126a348d3985aad9f69ecf7802c13efef90897e1c5ff7851974332c5e6d4a4698efe610fef758a068c8bc3feb5322aeb35d5993
+  checksum: 10c0/d21ccfc2595b2eddf7369f19797533573feb06820d8b5766467902a7a54e36b3a1f2b8cc2aa4481a2ad432c8e798576eabfac2f1ec0646a8e11a68694c2ef9d4
   languageName: node
   linkType: hard
 
@@ -7714,13 +7526,6 @@ __metadata:
   version: 2.0.28
   resolution: "mdn-data@npm:2.0.28"
   checksum: 10c0/20000932bc4cd1cde9cba4e23f08cc4f816398af4c15ec81040ed25421d6bf07b5cf6b17095972577fb498988f40f4cb589e3169b9357bb436a12d8e07e5ea7b
-  languageName: node
-  linkType: hard
-
-"mdn-data@npm:2.0.30":
-  version: 2.0.30
-  resolution: "mdn-data@npm:2.0.30"
-  checksum: 10c0/a2c472ea16cee3911ae742593715aa4c634eb3d4b9f1e6ada0902aa90df13dcbb7285d19435f3ff213ebaa3b2e0c0265c1eb0e3fb278fda7f8919f046a410cd9
   languageName: node
   linkType: hard
 
@@ -8590,15 +8395,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.1, once@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "once@npm:1.4.0"
-  dependencies:
-    wrappy: "npm:1"
-  checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
-  languageName: node
-  linkType: hard
-
 "onetime@npm:^7.0.0":
   version: 7.0.0
   resolution: "onetime@npm:7.0.0"
@@ -8702,7 +8498,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-manager-detector@npm:^1.3.0, package-manager-detector@npm:^1.6.0":
+"package-manager-detector@npm:^1.3.0":
+  version: 1.8.0
+  resolution: "package-manager-detector@npm:1.8.0"
+  checksum: 10c0/4c8e2c47fdc874465d3b3b11934401db9d73470ccbdabeb092e46cb94abbc491d5befc8c271b5ea1ae9c6a881f44c2997e011873365bde9fd6c3dc001221ff7a
+  languageName: node
+  linkType: hard
+
+"package-manager-detector@npm:^1.6.0":
   version: 1.6.0
   resolution: "package-manager-detector@npm:1.6.0"
   checksum: 10c0/6419d0b840be64fd45bcdcb7a19f09b81b65456d5e7f7a3daac305a4c90643052122f6ac0308afe548ffee75e36148532a2002ea9d292754f1e385aa2e1ea03b
@@ -8808,26 +8611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5-htmlparser2-tree-adapter@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "parse5-htmlparser2-tree-adapter@npm:7.1.0"
-  dependencies:
-    domhandler: "npm:^5.0.3"
-    parse5: "npm:^7.0.0"
-  checksum: 10c0/e5a4e0b834c84c9e244b5749f8d007f4baaeafac7a1da2c54be3421ffd9ef8fdec4f198bf55cda22e88e6ba95e9943f6ed5aa3ae5900b39972ebf5dc8c3f4722
-  languageName: node
-  linkType: hard
-
-"parse5-parser-stream@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "parse5-parser-stream@npm:7.1.2"
-  dependencies:
-    parse5: "npm:^7.0.0"
-  checksum: 10c0/e236c61000d38ecad369e725a48506b051cebad8abb00e6d4e8bff7aa85c183820fcb45db1559cc90955bdbbdbd665ea94c41259594e74566fff411478dc7fcb
-  languageName: node
-  linkType: hard
-
-"parse5@npm:^7.0.0, parse5@npm:^7.3.0":
+"parse5@npm:^7.0.0":
   version: 7.3.0
   resolution: "parse5@npm:7.3.0"
   dependencies:
@@ -8888,13 +8672,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pend@npm:~1.2.0":
-  version: 1.2.0
-  resolution: "pend@npm:1.2.0"
-  checksum: 10c0/8a87e63f7a4afcfb0f9f77b39bb92374afc723418b9cb716ee4257689224171002e07768eeade4ecd0e86f1fa3d8f022994219fb45634f2dbd78c6803e452458
-  languageName: node
-  linkType: hard
-
 "piccolore@npm:^0.1.3":
   version: 0.1.3
   resolution: "piccolore@npm:0.1.3"
@@ -8902,7 +8679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -8935,13 +8712,13 @@ __metadata:
   linkType: hard
 
 "pkg-types@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "pkg-types@npm:2.3.0"
+  version: 2.3.1
+  resolution: "pkg-types@npm:2.3.1"
   dependencies:
-    confbox: "npm:^0.2.2"
-    exsolve: "npm:^1.0.7"
+    confbox: "npm:^0.2.4"
+    exsolve: "npm:^1.0.8"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/d2bbddc5b81bd4741e1529c08ef4c5f1542bbdcf63498b73b8e1d84cff71806d1b8b1577800549bb569cb7aa20056257677b979bff48c97967cba7e64f72ae12
+  checksum: 10c0/dd9b20682426abaddcac9dc786aa22542e12df15a03dea2afa7bf54da0933358c6c7f545c0c3c1c7b24a2904ab4a451bf4e34a50c6837e458359eea30c257ed4
   languageName: node
   linkType: hard
 
@@ -9150,16 +8927,6 @@ __metadata:
     mathjax:
       optional: true
   checksum: 10c0/13b28581001155d2a4d2c3173985dc0dab7faf53964cb5a81a4a954fb1ff84632b77591e813e78323451001c91afc2e7b456482f47d56ff742474294b489b87c
-  languageName: node
-  linkType: hard
-
-"pump@npm:^3.0.0":
-  version: 3.0.4
-  resolution: "pump@npm:3.0.4"
-  dependencies:
-    end-of-stream: "npm:^1.1.0"
-    once: "npm:^1.3.1"
-  checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
   languageName: node
   linkType: hard
 
@@ -10489,23 +10256,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svgo@npm:^3.3.2":
-  version: 3.3.3
-  resolution: "svgo@npm:3.3.3"
-  dependencies:
-    commander: "npm:^7.2.0"
-    css-select: "npm:^5.1.0"
-    css-tree: "npm:^2.3.1"
-    css-what: "npm:^6.1.0"
-    csso: "npm:^5.0.5"
-    picocolors: "npm:^1.0.0"
-    sax: "npm:^1.5.0"
-  bin:
-    svgo: ./bin/svgo
-  checksum: 10c0/06568c6b0430f96748c557f0b17dc7de79b19fa16d13d7523527ede0ec727fc6d8e6a10e13ff106dc4372d2e6063a1dca7c455c495efb1b83857480425f9b965
-  languageName: node
-  linkType: hard
-
 "svgo@npm:^4.0.1":
   version: 4.0.1
   resolution: "svgo@npm:4.0.1"
@@ -10555,7 +10305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.2, tar@npm:^7.5.4":
+"tar@npm:^7.5.4":
   version: 7.5.13
   resolution: "tar@npm:7.5.13"
   dependencies:
@@ -10589,14 +10339,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.0.0, tinyexec@npm:^1.0.1, tinyexec@npm:^1.0.2, tinyexec@npm:^1.0.4":
+"tinyexec@npm:^1.0.0, tinyexec@npm:^1.0.2, tinyexec@npm:^1.0.4":
   version: 1.0.4
   resolution: "tinyexec@npm:1.0.4"
   checksum: 10c0/d4a5bbcf6bdb23527a4b74c4aa566f41432167112fe76f420ec7e3a90a3ecfd3a7d944383e2719fc3987b69400f7b928daf08700d145fb527c2e80ec01e198bd
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.2.4":
+"tinyexec@npm:^1.0.1, tinyexec@npm:^1.2.4":
   version: 1.2.4
   resolution: "tinyexec@npm:1.2.4"
   checksum: 10c0/153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
@@ -10829,13 +10579,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.19.0":
-  version: 7.24.5
-  resolution: "undici@npm:7.24.5"
-  checksum: 10c0/2a836f1f6ab078fde3eeb4cc8fd5b34eeaf52cfbdf16a9bab61b7223f43f7847bcd2125d1da7c4e3f5996c528bf9f7940015d39909bab80cfbd71b855470cf21
-  languageName: node
-  linkType: hard
-
 "unicode-trie@npm:^2.0.0":
   version: 2.0.0
   resolution: "unicode-trie@npm:2.0.0"
@@ -10965,6 +10708,45 @@ __metadata:
     unist-util-is: "npm:^6.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
   checksum: 10c0/a56e1bbbf63fcb55abe379e660b9a3367787e8be1e2473bdb7e86cfa6f32b6c1fa0092432d7040b8a30b2fc674bbbe024ffe6d03c3d6bf4839b064f584463a4e
+  languageName: node
+  linkType: hard
+
+"unplugin-icons@npm:^23.0.1":
+  version: 23.0.1
+  resolution: "unplugin-icons@npm:23.0.1"
+  dependencies:
+    "@antfu/install-pkg": "npm:^1.1.0"
+    "@iconify/utils": "npm:^3.1.0"
+    local-pkg: "npm:^1.1.2"
+    obug: "npm:^2.1.1"
+    unplugin: "npm:^2.3.11"
+  peerDependencies:
+    "@svgr/core": ">=7.0.0"
+    "@svgx/core": ^1.0.1
+    "@vue/compiler-sfc": ^3.0.2
+    svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+  peerDependenciesMeta:
+    "@svgr/core":
+      optional: true
+    "@svgx/core":
+      optional: true
+    "@vue/compiler-sfc":
+      optional: true
+    svelte:
+      optional: true
+  checksum: 10c0/a4e39f973370989349e9cf8e9b5596ad0bf83e03e2cc79d196a5e063d9ba71bbdd3a7bc24b43be4378c9977e9247275fef3508e93a3023e0d82563ece6e97530
+  languageName: node
+  linkType: hard
+
+"unplugin@npm:^2.3.11":
+  version: 2.3.11
+  resolution: "unplugin@npm:2.3.11"
+  dependencies:
+    "@jridgewell/remapping": "npm:^2.3.5"
+    acorn: "npm:^8.15.0"
+    picomatch: "npm:^4.0.3"
+    webpack-virtual-modules: "npm:^0.6.2"
+  checksum: 10c0/273c1eab0eca4470c7317428689295c31dbe8ab0b306504de9f03cd20c156debb4131bef24b27ac615862958c5dd950a3951d26c0723ea774652ab3624149cff
   languageName: node
   linkType: hard
 
@@ -11502,12 +11284,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-encoding@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "whatwg-encoding@npm:3.1.1"
-  dependencies:
-    iconv-lite: "npm:0.6.3"
-  checksum: 10c0/273b5f441c2f7fda3368a496c3009edbaa5e43b71b09728f90425e7f487e5cef9eb2b846a31bd760dd8077739c26faf6b5ca43a5f24033172b003b72cf61a93e
+"webpack-virtual-modules@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "webpack-virtual-modules@npm:0.6.2"
+  checksum: 10c0/5ffbddf0e84bf1562ff86cf6fcf039c74edf09d78358a6904a09bbd4484e8bb6812dc385fe14330b715031892dcd8423f7a88278b57c9f5002c84c2860179add
   languageName: node
   linkType: hard
 
@@ -11515,13 +11295,6 @@ __metadata:
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
   checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
-  languageName: node
-  linkType: hard
-
-"whatwg-mimetype@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "whatwg-mimetype@npm:4.0.0"
-  checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
   languageName: node
   linkType: hard
 
@@ -11667,13 +11440,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrappy@npm:1":
-  version: 1.0.2
-  resolution: "wrappy@npm:1.0.2"
-  checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
-  languageName: node
-  linkType: hard
-
 "ws@npm:^8.21.0":
   version: 8.21.0
   resolution: "ws@npm:8.21.0"
@@ -11810,16 +11576,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^22.0.0"
   checksum: 10c0/bf290e4723876ea9c638c786a5c42ac28e03c9ca2325e1424bf43b94e5876456292d3ed905b853ebbba6daf43ed29e772ac2a6b3c5fb1b16533245d6211778f3
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
-  dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10c0/f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
astro-icon is unmaintained (last release 1.1.5, Dec 2024) and only *warns* on an unknown icon name — e.g. an FA6 name in the FA5 `fa-solid` set — so typos ship silently instead of failing the build.

Switch to unplugin-icons (`compiler: 'astro'`), which keeps the same zero-JS inline-SVG output and the same @iconify-json data packages, so icons render identically:

- each icon is a static `~icons/<collection>/<name>` import; an unknown name is an unresolved import that fails the build (no include list)
- data-driven icons (SocialLinks/SocialShare/books) store the component in their data and render it: `{ Icon }` -> `<Icon />`

Verified: astro check 0 errors, 80 tests, build green.

BREAKING CHANGE: the `<Icon name="col:name" />` component and the
astro.config `icon.include` list are gone — add icons via a
`~icons/<collection>/<name>` import. Icons now render at 1.2em
(unplugin default) instead of 1em; pass `scale: 1` to keep the old size.