### PR TITLE
fix(config): move markdown plugins onto the unified() processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For project pages, keep `ASTRO_SITE` as the site origin, for example
 ### Option B — Local development
 
 ```bash
-# Prerequisites: Node 24+, Corepack enabled
+# Prerequisites: Node 24+, Astro 6.4+, Corepack enabled
 corepack enable
 
 # Clone
@@ -308,7 +308,7 @@ Already configured in `vercel.json`. Connect your repo in Vercel dashboard.
 
 | Layer           | Technology                                                                               |
 | --------------- | ---------------------------------------------------------------------------------------- |
-| Framework       | [Astro 6](https://astro.build)                                                           |
+| Framework       | [Astro 6.4+](https://astro.build)                                                        |
 | CSS             | [Tailwind CSS v4](https://tailwindcss.com)                                               |
 | Types           | TypeScript (strict)                                                                      |
 | Math            | KaTeX via remark-math + rehype-katex                                                     |

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,4 @@
+import { unified } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import partytown from '@astrojs/partytown';
 import react from '@astrojs/react';
@@ -123,18 +124,20 @@ export default defineConfig({
     },
   },
   markdown: {
-    remarkPlugins: [remarkMath, remarkBasePaths],
-    rehypePlugins: [
-      [rehypeKatex, { strict: false }],
-      [
-        rehypeExternalLinks,
-        {
-          target: '_blank',
-          rel: ['noopener', 'noreferrer'],
-        },
+    processor: unified({
+      remarkPlugins: [remarkMath, remarkBasePaths],
+      rehypePlugins: [
+        [rehypeKatex, { strict: false }],
+        [
+          rehypeExternalLinks,
+          {
+            target: '_blank',
+            rel: ['noopener', 'noreferrer'],
+          },
+        ],
+        rehypeBasePaths,
       ],
-      rehypeBasePaths,
-    ],
+    }),
     syntaxHighlight: 'shiki',
     shikiConfig: {
       themes: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,4 @@
+// Pinned to 7.2.0 (7.2.1 breaks Shiki in mdx blocks) — bump with astro.
 import { unified } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import partytown from '@astrojs/partytown';

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "citations:update": "node --strip-types scripts/update-citations.ts"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "7.2.0",
     "@astrojs/mdx": "^6.0.0",
     "@astrojs/partytown": "^2.1.7",
     "@astrojs/react": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "astro": ">=6.0.0"
+    "astro": ">=6.4.0"
   },
   "scripts": {
     "dev": "astro dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,7 +3604,7 @@ __metadata:
     unplugin-icons: "npm:^23.0.1"
     vitest: "npm:^4.1.9"
   peerDependencies:
-    astro: ">=6.0.0"
+    astro: ">=6.4.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3544,6 +3544,7 @@ __metadata:
   resolution: "as-folio@workspace:."
   dependencies:
     "@astrojs/check": "npm:^0.9.9"
+    "@astrojs/markdown-remark": "npm:7.2.0"
     "@astrojs/mdx": "npm:^6.0.0"
     "@astrojs/partytown": "npm:^2.1.7"
     "@astrojs/react": "npm:^5.0.7"


### PR DESCRIPTION
Astro 6.4 deprecated those top-level options and they are **scheduled for
removal in Astro 8** ([release notes](https://astro.build/blog/astro-640/), [#16848](https://github.com/withastro/astro/commit/f732f3cc716342a63e5b03815243ba10964b89dc)).

### Fix
Wrap the existing plugin lists in `markdown.processor: unified({...})`, exactly as
the Astro docs prescribe. Plugin **order is unchanged**, `syntaxHighlight` /
`shikiConfig` stay top-level (not deprecated), and `@astrojs/mdx` inherits the
processor — so `.md` and `.mdx` keep the identical pipeline (math/KaTeX, external
links, base-path rewriting).
